### PR TITLE
program/cli: Port over history from SPL

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.9.2"
-solana-cli-config = "1.9.2"
-solana-client = "1.9.2"
-solana-logger = "1.9.2"
-solana-sdk = "1.9.2"
+solana-clap-utils = "1.9.5"
+solana-cli-config = "1.9.5"
+solana-client = "1.9.5"
+solana-logger = "1.9.5"
+solana-sdk = "1.9.5"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.8.1"
-solana-cli-config = "1.8.1"
-solana-client = "1.8.1"
-solana-logger = "1.8.1"
-solana-sdk = "1.8.1"
+solana-clap-utils = "1.9.2"
+solana-cli-config = "1.9.2"
+solana-client = "1.9.2"
+solana-logger = "1.9.2"
+solana-sdk = "1.9.2"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.9.9"
-solana-cli-config = "1.9.9"
-solana-client = "1.9.9"
-solana-logger = "1.9.9"
-solana-sdk = "1.9.9"
+solana-clap-utils = "1.10.8"
+solana-cli-config = "1.10.8"
+solana-client = "1.10.8"
+solana-logger = "1.10.8"
+solana-sdk = "1.10.8"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.10.8"
-solana-cli-config = "1.10.8"
-solana-client = "1.10.8"
-solana-logger = "1.10.8"
-solana-sdk = "1.10.8"
+solana-clap-utils = "1.10.10"
+solana-cli-config = "1.10.10"
+solana-client = "1.10.10"
+solana-logger = "1.10.10"
+solana-sdk = "1.10.10"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 clap = "2.33.3"
-solana-clap-utils = "2.0.3"
-solana-cli-config = "2.0.3"
-solana-client = "2.0.3"
-solana-logger = "2.0.3"
-solana-sdk = "2.0.3"
+solana-clap-utils = "2.1.0"
+solana-cli-config = "2.1.0"
+solana-client = "2.1.0"
+solana-logger = "2.1.0"
+solana-sdk = "2.1.0"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.26"
 clap = "2.33.3"
-solana-clap-utils = "1.14.12"
-solana-cli-config = "1.14.12"
-solana-client = "1.14.12"
-solana-logger = "1.14.12"
-solana-sdk = "1.14.12"
+solana-clap-utils = "1.16.1"
+solana-cli-config = "1.16.1"
+solana-client = "1.16.1"
+solana-logger = "1.16.1"
+solana-sdk = "1.16.1"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.22"
+chrono = "0.4.24"
 clap = "2.33.3"
 solana-clap-utils = "1.14.12"
 solana-cli-config = "1.14.12"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.9.5"
-solana-cli-config = "1.9.5"
-solana-client = "1.9.5"
-solana-logger = "1.9.5"
-solana-sdk = "1.9.5"
+solana-clap-utils = "1.9.9"
+solana-cli-config = "1.9.9"
+solana-client = "1.9.9"
+solana-logger = "1.9.9"
+solana-sdk = "1.9.9"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.8.0"
-solana-cli-config = "1.8.0"
-solana-client = "1.8.0"
-solana-logger = "1.8.0"
-solana-sdk = "1.8.0"
+solana-clap-utils = "1.8.1"
+solana-cli-config = "1.8.1"
+solana-client = "1.8.1"
+solana-logger = "1.8.1"
+solana-sdk = "1.8.1"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.10.10"
-solana-cli-config = "1.10.10"
-solana-client = "1.10.10"
-solana-logger = "1.10.10"
-solana-sdk = "1.10.10"
+solana-clap-utils = "1.10.15"
+solana-cli-config = "1.10.15"
+solana-client = "1.10.15"
+solana-logger = "1.10.15"
+solana-sdk = "1.10.15"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.37"
+chrono = "0.4.38"
 clap = "2.33.3"
 solana-clap-utils = ">=1.18.2,<=2"
 solana-cli-config = ">=1.18.2,<=2"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.11.6"
-solana-cli-config = "1.11.6"
-solana-client = "1.11.6"
-solana-logger = "1.11.6"
-solana-sdk = "1.11.6"
+solana-clap-utils = "1.14.4"
+solana-cli-config = "1.14.4"
+solana-client = "1.14.4"
+solana-logger = "1.14.4"
+solana-sdk = "1.14.4"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.24"
+chrono = "0.4.25"
 clap = "2.33.3"
 solana-clap-utils = "1.14.12"
 solana-cli-config = "1.14.12"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -5,7 +5,7 @@ description = "SPL Feature Proposal Command-line Utility"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 chrono = "0.4.22"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.26"
+chrono = "0.4.27"
 clap = "2.33.3"
 solana-clap-utils = "1.16.3"
 solana-cli-config = "1.16.3"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.10.35"
-solana-cli-config = "1.10.35"
-solana-client = "1.10.35"
-solana-logger = "1.10.35"
-solana-sdk = "1.10.35"
+solana-clap-utils = "1.11.6"
+solana-cli-config = "1.11.6"
+solana-client = "1.11.6"
+solana-logger = "1.11.6"
+solana-sdk = "1.11.6"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.22"
 clap = "2.33.3"
-solana-clap-utils = "1.14.6"
-solana-cli-config = "1.14.6"
-solana-client = "1.14.6"
-solana-logger = "1.14.6"
-solana-sdk = "1.14.6"
+solana-clap-utils = "1.14.10"
+solana-cli-config = "1.14.10"
+solana-client = "1.14.10"
+solana-logger = "1.14.10"
+solana-sdk = "1.14.10"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.25"
+chrono = "0.4.26"
 clap = "2.33.3"
 solana-clap-utils = "1.14.12"
 solana-cli-config = "1.14.12"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.27"
+chrono = "0.4.28"
 clap = "2.33.3"
 solana-clap-utils = "1.16.3"
 solana-cli-config = "1.16.3"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.28"
+chrono = "0.4.29"
 clap = "2.33.3"
 solana-clap-utils = "1.16.3"
 solana-cli-config = "1.16.3"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.10.33"
-solana-cli-config = "1.10.33"
-solana-client = "1.10.33"
-solana-logger = "1.10.33"
-solana-sdk = "1.10.33"
+solana-clap-utils = "1.10.35"
+solana-cli-config = "1.10.35"
+solana-client = "1.10.35"
+solana-logger = "1.10.35"
+solana-sdk = "1.10.35"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-chrono = "0.4.19"
+chrono = "0.4.22"
 clap = "2.33.3"
 solana-clap-utils = "1.14.4"
 solana-cli-config = "1.14.4"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.22"
 clap = "2.33.3"
-solana-clap-utils = "1.14.4"
-solana-cli-config = "1.14.4"
-solana-client = "1.14.4"
-solana-logger = "1.14.4"
-solana-sdk = "1.14.4"
+solana-clap-utils = "1.14.6"
+solana-cli-config = "1.14.6"
+solana-client = "1.14.6"
+solana-logger = "1.14.6"
+solana-sdk = "1.14.6"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.30"
+chrono = "0.4.31"
 clap = "2.33.3"
 solana-clap-utils = "1.16.3"
 solana-cli-config = "1.16.3"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.29"
+chrono = "0.4.30"
 clap = "2.33.3"
 solana-clap-utils = "1.16.3"
 solana-cli-config = "1.16.3"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.22"
 clap = "2.33.3"
-solana-clap-utils = "1.14.10"
-solana-cli-config = "1.14.10"
-solana-client = "1.14.10"
-solana-logger = "1.14.10"
-solana-sdk = "1.14.10"
+solana-clap-utils = "1.14.12"
+solana-cli-config = "1.14.12"
+solana-client = "1.14.12"
+solana-logger = "1.14.12"
+solana-sdk = "1.14.12"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.31"
 clap = "2.33.3"
-solana-clap-utils = "1.16.3"
-solana-cli-config = "1.16.3"
-solana-client = "1.16.3"
-solana-logger = "1.16.3"
-solana-sdk = "1.16.3"
+solana-clap-utils = "1.16.13"
+solana-cli-config = "1.16.13"
+solana-client = "1.16.13"
+solana-logger = "1.16.13"
+solana-sdk = "1.16.13"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.26"
 clap = "2.33.3"
-solana-clap-utils = "1.16.1"
-solana-cli-config = "1.16.1"
-solana-client = "1.16.1"
-solana-logger = "1.16.1"
-solana-sdk = "1.16.1"
+solana-clap-utils = "1.16.3"
+solana-cli-config = "1.16.3"
+solana-client = "1.16.3"
+solana-logger = "1.16.3"
+solana-sdk = "1.16.3"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "spl-feature-proposal-cli"
 version = "1.2.0"
 description = "SPL Feature Proposal Command-line Utility"
-authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
 edition = "2021"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.10.15"
-solana-cli-config = "1.10.15"
-solana-client = "1.10.15"
-solana-logger = "1.10.15"
-solana-sdk = "1.10.15"
+solana-clap-utils = "1.10.29"
+solana-cli-config = "1.10.29"
+solana-client = "1.10.29"
+solana-logger = "1.10.29"
+solana-sdk = "1.10.29"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.33"
+chrono = "0.4.34"
 clap = "2.33.3"
 solana-clap-utils = ">=1.17.17,<=2"
 solana-cli-config = ">=1.17.17,<=2"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.31"
 clap = "2.33.3"
-solana-clap-utils = "1.16.13"
-solana-cli-config = "1.16.13"
-solana-client = "1.16.13"
-solana-logger = "1.16.13"
-solana-sdk = "1.16.13"
+solana-clap-utils = "1.16.16"
+solana-cli-config = "1.16.16"
+solana-client = "1.16.16"
+solana-logger = "1.16.16"
+solana-sdk = "1.16.16"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.31"
 clap = "2.33.3"
-solana-clap-utils = "1.17.6"
-solana-cli-config = "1.17.6"
-solana-client = "1.17.6"
-solana-logger = "1.17.6"
-solana-sdk = "1.17.6"
+solana-clap-utils = "1.17.13"
+solana-cli-config = "1.17.13"
+solana-client = "1.17.13"
+solana-logger = "1.17.13"
+solana-sdk = "1.17.13"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.34"
 clap = "2.33.3"
-solana-clap-utils = ">=1.17.17,<=2"
-solana-cli-config = ">=1.17.17,<=2"
-solana-client = ">=1.17.17,<=2"
-solana-logger = ">=1.17.17,<=2"
-solana-sdk = ">=1.17.17,<=2"
+solana-clap-utils = ">=1.18.2,<=2"
+solana-cli-config = ">=1.18.2,<=2"
+solana-client = ">=1.18.2,<=2"
+solana-logger = ">=1.18.2,<=2"
+solana-sdk = ">=1.18.2,<=2"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.19"
 clap = "2.33.3"
-solana-clap-utils = "1.10.29"
-solana-cli-config = "1.10.29"
-solana-client = "1.10.29"
-solana-logger = "1.10.29"
-solana-sdk = "1.10.29"
+solana-clap-utils = "1.10.33"
+solana-cli-config = "1.10.33"
+solana-client = "1.10.33"
+solana-logger = "1.10.33"
+solana-sdk = "1.10.33"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.31"
 clap = "2.33.3"
-solana-clap-utils = "1.16.16"
-solana-cli-config = "1.16.16"
-solana-client = "1.16.16"
-solana-logger = "1.16.16"
-solana-sdk = "1.16.16"
+solana-clap-utils = "1.17.2"
+solana-cli-config = "1.17.2"
+solana-client = "1.17.2"
+solana-logger = "1.17.2"
+solana-sdk = "1.17.2"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.33"
 clap = "2.33.3"
-solana-clap-utils = "1.17.13"
-solana-cli-config = "1.17.13"
-solana-client = "1.17.13"
-solana-logger = "1.17.13"
-solana-sdk = "1.17.13"
+solana-clap-utils = ">=1.17.13,<=2"
+solana-cli-config = ">=1.17.13,<=2"
+solana-client = ">=1.17.13,<=2"
+solana-logger = ">=1.17.13,<=2"
+solana-sdk = ">=1.17.13,<=2"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.31"
 clap = "2.33.3"
-solana-clap-utils = "1.17.2"
-solana-cli-config = "1.17.2"
-solana-client = "1.17.2"
-solana-logger = "1.17.2"
-solana-sdk = "1.17.2"
+solana-clap-utils = "1.17.6"
+solana-cli-config = "1.17.6"
+solana-client = "1.17.6"
+solana-logger = "1.17.6"
+solana-sdk = "1.17.6"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.34"
+chrono = "0.4.35"
 clap = "2.33.3"
 solana-clap-utils = ">=1.18.2,<=2"
 solana-cli-config = ">=1.18.2,<=2"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.33"
 clap = "2.33.3"
-solana-clap-utils = ">=1.17.13,<=2"
-solana-cli-config = ">=1.17.13,<=2"
-solana-client = ">=1.17.13,<=2"
-solana-logger = ">=1.17.13,<=2"
-solana-sdk = ">=1.17.13,<=2"
+solana-clap-utils = ">=1.17.17,<=2"
+solana-cli-config = ">=1.17.17,<=2"
+solana-client = ">=1.17.17,<=2"
+solana-logger = ">=1.17.17,<=2"
+solana-sdk = ">=1.17.17,<=2"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.31"
+chrono = "0.4.32"
 clap = "2.33.3"
 solana-clap-utils = "1.17.13"
 solana-cli-config = "1.17.13"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.32"
+chrono = "0.4.33"
 clap = "2.33.3"
 solana-clap-utils = "1.17.13"
 solana-cli-config = "1.17.13"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4.35"
+chrono = "0.4.37"
 clap = "2.33.3"
 solana-clap-utils = ">=1.18.2,<=2"
 solana-cli-config = ">=1.18.2,<=2"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 clap = "2.33.3"
-solana-clap-utils = ">=1.18.2,<=2"
-solana-cli-config = ">=1.18.2,<=2"
-solana-client = ">=1.18.2,<=2"
-solana-logger = ">=1.18.2,<=2"
-solana-sdk = ">=1.18.2,<=2"
+solana-clap-utils = ">=1.18.11,<=2"
+solana-cli-config = ">=1.18.11,<=2"
+solana-client = ">=1.18.11,<=2"
+solana-logger = ">=1.18.11,<=2"
+solana-sdk = ">=1.18.11,<=2"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 clap = "2.33.3"
-solana-clap-utils = ">=1.18.11,<=2"
-solana-cli-config = ">=1.18.11,<=2"
-solana-client = ">=1.18.11,<=2"
-solana-logger = ">=1.18.11,<=2"
-solana-sdk = ">=1.18.11,<=2"
+solana-clap-utils = "2.0.0"
+solana-cli-config = "2.0.0"
+solana-client = "2.0.0"
+solana-logger = "2.0.0"
+solana-sdk = "2.0.0"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 clap = "2.33.3"
-solana-clap-utils = "2.0.0"
-solana-cli-config = "2.0.0"
-solana-client = "2.0.0"
-solana-logger = "2.0.0"
-solana-sdk = "2.0.0"
+solana-clap-utils = "2.0.3"
+solana-cli-config = "2.0.3"
+solana-client = "2.0.3"
+solana-logger = "2.0.3"
+solana-sdk = "2.0.3"
 spl-feature-proposal = { version = "1.0", path = "../program", features = ["no-entrypoint"] }
 
 [[bin]]

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -328,7 +328,7 @@ fn process_propose(
         )],
         Some(&config.keypair.pubkey()),
     );
-    let blockhash = rpc_client.get_recent_blockhash()?.0;
+    let blockhash = rpc_client.get_latest_blockhash()?;
     transaction.try_sign(&[&config.keypair, feature_proposal_keypair], blockhash)?;
 
     println!("JSON RPC URL: {}", config.json_rpc_url);
@@ -462,7 +462,7 @@ fn process_tally(
         )],
         Some(&config.keypair.pubkey()),
     );
-    let blockhash = rpc_client.get_recent_blockhash()?.0;
+    let blockhash = rpc_client.get_latest_blockhash()?;
     transaction.try_sign(&[&config.keypair], blockhash)?;
 
     rpc_client.send_and_confirm_transaction_with_spinner(&transaction)?;

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -250,8 +250,8 @@ fn unix_timestamp_to_string(unix_timestamp: UnixTimestamp) -> String {
     format!(
         "{} (UnixTimestamp: {})",
         match NaiveDateTime::from_timestamp_opt(unix_timestamp, 0) {
-            Some(ndt) =>
-                DateTime::<Utc>::from_utc(ndt, Utc).to_rfc3339_opts(SecondsFormat::Secs, true),
+            Some(ndt) => DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc)
+                .to_rfc3339_opts(SecondsFormat::Secs, true),
             None => "unknown".to_string(),
         },
         unix_timestamp,

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -358,12 +358,12 @@ fn process_propose(
         the proposal by first looking up their token account address:"
     );
     println!(
-        "    $ spl-token --owner ~/validator-keypair.json accounts {}",
+        "    $ spl-token accounts --owner ~/validator-keypair.json {}",
         mint_address
     );
     println!("and then submit their vote by running:");
     println!(
-        "    $ spl-token --owner ~/validator-keypair.json transfer <TOKEN_ACCOUNT_ADDRESS> ALL {}",
+        "    $ spl-token transfer --owner ~/validator-keypair.json <TOKEN_ACCOUNT_ADDRESS> ALL {}",
         acceptance_token_address
     );
     println!();

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use {
     chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc},
     clap::{

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc},
+    chrono::{DateTime, SecondsFormat, Utc},
     clap::{
         crate_description, crate_name, crate_version, value_t_or_exit, App, AppSettings, Arg,
         SubCommand,
@@ -249,11 +249,9 @@ fn get_feature_proposal(
 fn unix_timestamp_to_string(unix_timestamp: UnixTimestamp) -> String {
     format!(
         "{} (UnixTimestamp: {})",
-        match NaiveDateTime::from_timestamp_opt(unix_timestamp, 0) {
-            Some(ndt) => DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc)
-                .to_rfc3339_opts(SecondsFormat::Secs, true),
-            None => "unknown".to_string(),
-        },
+        DateTime::<Utc>::from_timestamp(unix_timestamp, 0)
+            .map(|x| x.to_rfc3339_opts(SecondsFormat::Secs, true))
+            .unwrap_or("unknown".to_string()),
         unix_timestamp,
     )
 }

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
+#![allow(clippy::arithmetic_side_effects)]
 use {
     chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc},
     clap::{

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.8.1"
+solana-program = "1.9.2"
 spl-token = { version = "3.2", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.8.1"
-solana-sdk = "1.8.1"
+solana-program-test = "1.9.2"
+solana-sdk = "1.9.2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.10.8"
+solana-program = "1.10.10"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.10.8"
-solana-sdk = "1.10.8"
+solana-program-test = "1.10.10"
+solana-sdk = "1.10.10"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.9.9"
+solana-program = "1.10.8"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.9.9"
-solana-sdk = "1.9.9"
+solana-program-test = "1.10.8"
+solana-sdk = "1.10.8"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.9.5"
+solana-program = "1.9.9"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.9.5"
-solana-sdk = "1.9.5"
+solana-program-test = "1.9.9"
+solana-sdk = "1.9.9"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.9.2"
+solana-program = "1.9.5"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.9.2"
-solana-sdk = "1.9.2"
+solana-program-test = "1.9.5"
+solana-sdk = "1.9.5"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -15,7 +15,7 @@ test-bpf = []
 borsh = "0.9"
 borsh-derive = "0.9.0"
 solana-program = "1.9.2"
-spl-token = { version = "3.2", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.9.2"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.10.10"
+solana-program = "1.10.15"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.10.10"
-solana-sdk = "1.10.10"
+solana-program-test = "1.10.15"
+solana-sdk = "1.10.15"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.8.0"
+solana-program = "1.8.1"
 spl-token = { version = "3.2", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.8.0"
-solana-sdk = "1.8.0"
+solana-program-test = "1.8.1"
+solana-sdk = "1.8.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,13 +12,15 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "0.10"
-solana-program = ">=1.17.17,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
+borsh = "1.2.1"
+solana-program = ">=1.18.2,<=2"
+spl-token = { version = "4.0", path = "../../token/program", features = [
+  "no-entrypoint",
+] }
 
 [dev-dependencies]
-solana-program-test = ">=1.17.17,<=2"
-solana-sdk = ">=1.17.17,<=2"
+solana-program-test = ">=1.18.2,<=2"
+solana-sdk = ">=1.18.2,<=2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.10.33"
+solana-program = "1.10.35"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.10.33"
-solana-sdk = "1.10.33"
+solana-program-test = "1.10.35"
+solana-sdk = "1.10.35"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.16.3"
+solana-program = "1.16.13"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.16.3"
-solana-sdk = "1.16.3"
+solana-program-test = "1.16.13"
+solana-sdk = "1.16.13"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,7 +13,6 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.9"
-borsh-derive = "0.9.0"
 solana-program = "1.14.10"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-sbf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.14.6"
+solana-program = "1.14.10"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.14.6"
-solana-sdk = "1.14.6"
+solana-program-test = "1.14.10"
+solana-sdk = "1.14.10"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.9"
-solana-program = "1.14.10"
+solana-program = "1.14.12"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.14.10"
-solana-sdk = "1.14.10"
+solana-program-test = "1.14.12"
+solana-sdk = "1.14.12"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.16.1"
+solana-program = "1.16.3"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.16.1"
-solana-sdk = "1.16.1"
+solana-program-test = "1.16.3"
+solana-sdk = "1.16.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-sbf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.11.6"
+solana-program = "1.14.4"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.11.6"
-solana-sdk = "1.11.6"
+solana-program-test = "1.14.4"
+solana-sdk = "1.14.4"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "spl-feature-proposal"
 version = "1.0.0"
 description = "Solana Program Library Feature Proposal Program"
-authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
 edition = "2021"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -9,17 +9,17 @@ edition = "2018"
 
 [features]
 no-entrypoint = []
-test-bpf = []
+test-sbf = []
 
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.10.35"
+solana-program = "1.11.6"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.10.35"
-solana-sdk = "1.10.35"
+solana-program-test = "1.11.6"
+solana-sdk = "1.11.6"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -5,7 +5,7 @@ description = "Solana Program Library Feature Proposal Program"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
 repository = "https://github.com/solana-labs/solana-program-library"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 no-entrypoint = []

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-sbf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.14.4"
+solana-program = "1.14.6"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.14.4"
-solana-sdk = "1.14.4"
+solana-program-test = "1.14.6"
+solana-sdk = "1.14.6"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 borsh = "0.10"
 solana-program = "1.16.1"
-spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.16.1"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,13 +12,13 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "0.9"
-solana-program = "1.14.12"
+borsh = "0.10"
+solana-program = "1.16.1"
 spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.14.12"
-solana-sdk = "1.14.12"
+solana-program-test = "1.16.1"
+solana-sdk = "1.16.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.17.6"
+solana-program = "1.17.13"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.17.6"
-solana-sdk = "1.17.6"
+solana-program-test = "1.17.13"
+solana-sdk = "1.17.13"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.17.13"
+solana-program = ">=1.17.13,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.17.13"
-solana-sdk = "1.17.13"
+solana-program-test = ">=1.17.13,<=2"
+solana-sdk = ">=1.17.13,<=2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -15,7 +15,7 @@ test-bpf = []
 borsh = "0.9"
 borsh-derive = "0.9.0"
 solana-program = "1.10.33"
-spl-token = { version = "3.4", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.5", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.10.33"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -15,7 +15,7 @@ test-bpf = []
 borsh = "0.9"
 borsh-derive = "0.9.0"
 solana-program = "1.10.33"
-spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
+spl-token = { version = "3.4", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
 solana-program-test = "1.10.33"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = ">=1.17.13,<=2"
+solana-program = ">=1.17.17,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = ">=1.17.13,<=2"
-solana-sdk = ">=1.17.13,<=2"
+solana-program-test = ">=1.17.17,<=2"
+solana-sdk = ">=1.17.17,<=2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.10.15"
+solana-program = "1.10.29"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.10.15"
-solana-sdk = "1.10.15"
+solana-program-test = "1.10.29"
+solana-sdk = "1.10.29"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.16.16"
+solana-program = "1.17.2"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.16.16"
-solana-sdk = "1.16.16"
+solana-program-test = "1.17.2"
+solana-sdk = "1.17.2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.17.2"
+solana-program = "1.17.6"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.17.2"
-solana-sdk = "1.17.2"
+solana-program-test = "1.17.6"
+solana-sdk = "1.17.6"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,12 +14,12 @@ test-bpf = []
 [dependencies]
 borsh = "0.9"
 borsh-derive = "0.9.0"
-solana-program = "1.10.29"
+solana-program = "1.10.33"
 spl-token = { version = "3.3", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.10.29"
-solana-sdk = "1.10.29"
+solana-program-test = "1.10.33"
+solana-sdk = "1.10.33"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,12 +13,12 @@ test-sbf = []
 
 [dependencies]
 borsh = "0.10"
-solana-program = "1.16.13"
+solana-program = "1.16.16"
 spl-token = { version = "4.0", path = "../../token/program", features = ["no-entrypoint"] }
 
 [dev-dependencies]
-solana-program-test = "1.16.13"
-solana-sdk = "1.16.13"
+solana-program-test = "1.16.16"
+solana-sdk = "1.16.16"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "1.2.1"
+borsh = "1.4.0"
 solana-program = ">=1.18.2,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,14 +13,14 @@ test-sbf = []
 
 [dependencies]
 borsh = "1.4.0"
-solana-program = ">=1.18.2,<=2"
+solana-program = ">=1.18.11,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 
 [dev-dependencies]
-solana-program-test = ">=1.18.2,<=2"
-solana-sdk = ">=1.18.2,<=2"
+solana-program-test = ">=1.18.11,<=2"
+solana-sdk = ">=1.18.11,<=2"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "1.5.0"
+borsh = "1.5.1"
 solana-program = ">=1.18.11,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "1.4.0"
+borsh = "1.5.0"
 solana-program = ">=1.18.11,<=2"
 spl-token = { version = "4.0", path = "../../token/program", features = [
   "no-entrypoint",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "1.5.1"
+borsh = "1.5.2"
 solana-program = "2.1.0"
 spl-token = { version = "7.0", path = "../../token/program", features = [
   "no-entrypoint",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,7 +12,7 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-borsh = "1.5.2"
+borsh = "1.5.3"
 solana-program = "2.1.0"
 spl-token = { version = "7.0", path = "../../token/program", features = [
   "no-entrypoint",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,14 +13,14 @@ test-sbf = []
 
 [dependencies]
 borsh = "1.5.1"
-solana-program = "2.0.0"
+solana-program = "2.0.3"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 
 [dev-dependencies]
-solana-program-test = "2.0.0"
-solana-sdk = "2.0.0"
+solana-program-test = "2.0.3"
+solana-sdk = "2.0.3"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,17 +13,20 @@ test-sbf = []
 
 [dependencies]
 borsh = "1.5.1"
-solana-program = "2.0.3"
+solana-program = "2.1.0"
 spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 
 [dev-dependencies]
-solana-program-test = "2.0.3"
-solana-sdk = "2.0.3"
+solana-program-test = "2.1.0"
+solana-sdk = "2.1.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 borsh = "1.5.1"
 solana-program = "2.1.0"
-spl-token = { version = "6.0", path = "../../token/program", features = [
+spl-token = { version = "7.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 borsh = "1.5.1"
 solana-program = "2.0.0"
-spl-token = { version = "5.0", path = "../../token/program", features = [
+spl-token = { version = "6.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,7 +14,7 @@ test-sbf = []
 [dependencies]
 borsh = "1.5.1"
 solana-program = ">=1.18.11,<=2"
-spl-token = { version = "4.0", path = "../../token/program", features = [
+spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,14 +13,14 @@ test-sbf = []
 
 [dependencies]
 borsh = "1.5.1"
-solana-program = ">=1.18.11,<=2"
+solana-program = "2.0.0"
 spl-token = { version = "5.0", path = "../../token/program", features = [
   "no-entrypoint",
 ] }
 
 [dev-dependencies]
-solana-program-test = ">=1.18.11,<=2"
-solana-sdk = ">=1.18.11,<=2"
+solana-program-test = "2.0.0"
+solana-sdk = "2.0.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Program entrypoint
 
-#![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
+#![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
 use solana_program::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -2,11 +2,9 @@
 
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
-use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
-entrypoint!(process_instruction);
+solana_program::entrypoint!(process_instruction);
 fn process_instruction(
     program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -107,7 +107,7 @@ impl Pack for FeatureProposalInstruction {
 
 impl FeatureProposalInstruction {
     fn pack_into_vec(&self) -> Vec<u8> {
-        self.try_to_vec().expect("try_to_vec")
+        borsh::to_vec(self).expect("try_to_vec")
     }
 }
 
@@ -170,26 +170,25 @@ mod tests {
     fn test_get_packed_len() {
         assert_eq!(
             FeatureProposalInstruction::get_packed_len(),
-            solana_program::borsh0_10::get_packed_len::<FeatureProposalInstruction>()
+            solana_program::borsh1::get_packed_len::<FeatureProposalInstruction>()
         )
     }
 
     #[test]
     fn test_serialize_bytes() {
         assert_eq!(
-            FeatureProposalInstruction::Tally.try_to_vec().unwrap(),
+            borsh::to_vec(&FeatureProposalInstruction::Tally).unwrap(),
             vec![1]
         );
 
         assert_eq!(
-            FeatureProposalInstruction::Propose {
+            borsh::to_vec(&FeatureProposalInstruction::Propose {
                 tokens_to_mint: 42,
                 acceptance_criteria: AcceptanceCriteria {
                     tokens_required: 0xdeadbeefdeadbeef,
                     deadline: -1,
                 }
-            }
-            .try_to_vec()
+            })
             .unwrap(),
             vec![
                 0, 42, 0, 0, 0, 0, 0, 0, 0, 239, 190, 173, 222, 239, 190, 173, 222, 255, 255, 255,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -160,7 +160,7 @@ mod tests {
     fn test_get_packed_len() {
         assert_eq!(
             FeatureProposalInstruction::get_packed_len(),
-            solana_program::borsh::get_packed_len::<FeatureProposalInstruction>()
+            solana_program::borsh0_10::get_packed_len::<FeatureProposalInstruction>()
         )
     }
 

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -18,38 +18,44 @@ use {
 pub enum FeatureProposalInstruction {
     /// Propose a new feature.
     ///
-    /// This instruction will create a variety of accounts to support the feature proposal, all
-    /// funded by account 0:
-    /// * A new token mint with a supply of `tokens_to_mint`, owned by the program and never
-    ///   modified again
-    /// * A new "distributor" token account that holds the total supply, owned by account 0.
-    /// * A new "acceptance" token account that holds 0 tokens, owned by the program.  Tokens
-    ///   transfers to this address are irrevocable and permanent.
-    /// * A new feature id account that has been funded and allocated (as described in
-    ///  `solana_program::feature`)
+    /// This instruction will create a variety of accounts to support the
+    /// feature proposal, all funded by account 0:
+    /// * A new token mint with a supply of `tokens_to_mint`, owned by the
+    ///   program and never modified again
+    /// * A new "distributor" token account that holds the total supply, owned
+    ///   by account 0.
+    /// * A new "acceptance" token account that holds 0 tokens, owned by the
+    ///   program.  Tokens transfers to this address are irrevocable and
+    ///   permanent.
+    /// * A new feature id account that has been funded and allocated (as
+    ///   described in `solana_program::feature`)
     ///
-    /// On successful execution of the instruction, the feature proposer is expected to distribute
-    /// the tokens in the distributor token account out to all participating parties.
+    /// On successful execution of the instruction, the feature proposer is
+    /// expected to distribute the tokens in the distributor token account
+    /// out to all participating parties.
     ///
-    /// Based on the provided acceptance criteria, if `AcceptanceCriteria::tokens_required`
-    /// tokens are transferred into the acceptance token account before
-    /// `AcceptanceCriteria::deadline` then the proposal is eligible to be accepted.
+    /// Based on the provided acceptance criteria, if
+    /// `AcceptanceCriteria::tokens_required` tokens are transferred into
+    /// the acceptance token account before `AcceptanceCriteria::deadline`
+    /// then the proposal is eligible to be accepted.
     ///
-    /// The `FeatureProposalInstruction::Tally` instruction must be executed, by any party, to
-    /// complete the feature acceptance process.
+    /// The `FeatureProposalInstruction::Tally` instruction must be executed, by
+    /// any party, to complete the feature acceptance process.
     ///
     /// Accounts expected by this instruction:
     ///
     /// 0. `[writeable,signer]` Funding account (must be a system account)
     /// 1. `[writeable,signer]` Unallocated feature proposal account to create
     /// 2. `[writeable]` Token mint address from `get_mint_address`
-    /// 3. `[writeable]` Distributor token account address from `get_distributor_token_address`
-    /// 4. `[writeable]` Acceptance token account address from `get_acceptance_token_address`
-    /// 5. `[writeable]` Feature id account address from `get_feature_id_address`
+    /// 3. `[writeable]` Distributor token account address from
+    ///    `get_distributor_token_address`
+    /// 4. `[writeable]` Acceptance token account address from
+    ///    `get_acceptance_token_address`
+    /// 5. `[writeable]` Feature id account address from
+    ///    `get_feature_id_address`
     /// 6. `[]` System program
     /// 7. `[]` SPL Token program
     /// 8. `[]` Rent sysvar
-    ///
     Propose {
         /// Total number of tokens to mint for this proposal
         #[allow(dead_code)] // not dead code..
@@ -60,8 +66,8 @@ pub enum FeatureProposalInstruction {
         acceptance_criteria: AcceptanceCriteria,
     },
 
-    /// `Tally` is a permission-less instruction to check the acceptance criteria for the feature
-    /// proposal, which may result in:
+    /// `Tally` is a permission-less instruction to check the acceptance
+    /// criteria for the feature proposal, which may result in:
     /// * No action
     /// * Feature proposal acceptance
     /// * Feature proposal expiration
@@ -69,8 +75,10 @@ pub enum FeatureProposalInstruction {
     /// Accounts expected by this instruction:
     ///
     /// 0. `[writeable]` Feature proposal account
-    /// 1. `[]` Acceptance token account address from `get_acceptance_token_address`
-    /// 2. `[writeable]` Derived feature id account address from `get_feature_id_address`
+    /// 1. `[]` Acceptance token account address from
+    ///    `get_acceptance_token_address`
+    /// 2. `[writeable]` Derived feature id account address from
+    ///    `get_feature_id_address`
     /// 3. `[]` System program
     /// 4. `[]` Clock sysvar
     Tally,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,14 +1,16 @@
 //! Program instructions
 
-use crate::{state::AcceptanceCriteria, *};
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    msg,
-    program_error::ProgramError,
-    program_pack::{Pack, Sealed},
-    pubkey::Pubkey,
-    sysvar,
+use {
+    crate::{state::AcceptanceCriteria, *},
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        instruction::{AccountMeta, Instruction},
+        msg,
+        program_error::ProgramError,
+        program_pack::{Pack, Sealed},
+        pubkey::Pubkey,
+        sysvar,
+    },
 };
 
 /// Instructions supported by the Feature Proposal program

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -7,7 +7,8 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 
-// Export current SDK types for downstream users building with a different SDK version
+// Export current SDK types for downstream users building with a different SDK
+// version
 pub use solana_program;
 use solana_program::{program_pack::Pack, pubkey::Pubkey};
 
@@ -47,14 +48,14 @@ pub fn get_mint_address(feature_proposal_address: &Pubkey) -> Pubkey {
     get_mint_address_with_seed(feature_proposal_address).0
 }
 
-/// Derive the SPL Token token address associated with a feature proposal that receives the initial
-/// minted tokens
+/// Derive the SPL Token token address associated with a feature proposal that
+/// receives the initial minted tokens
 pub fn get_distributor_token_address(feature_proposal_address: &Pubkey) -> Pubkey {
     get_distributor_token_address_with_seed(feature_proposal_address).0
 }
 
-/// Derive the SPL Token token address associated with a feature proposal that users send their
-/// tokens to accept the proposal
+/// Derive the SPL Token token address associated with a feature proposal that
+/// users send their tokens to accept the proposal
 pub fn get_acceptance_token_address(feature_proposal_address: &Pubkey) -> Pubkey {
     get_acceptance_token_address_with_seed(feature_proposal_address).0
 }
@@ -64,13 +65,14 @@ pub fn get_feature_id_address(feature_proposal_address: &Pubkey) -> Pubkey {
     get_feature_id_address_with_seed(feature_proposal_address).0
 }
 
-/// Convert the UI representation of a token amount (using the decimals field defined in its mint)
-/// to the raw amount
+/// Convert the UI representation of a token amount (using the decimals field
+/// defined in its mint) to the raw amount
 pub fn ui_amount_to_amount(ui_amount: f64) -> u64 {
     (ui_amount * 10_usize.pow(spl_token::native_mint::DECIMALS as u32) as f64) as u64
 }
 
-/// Convert a raw amount to its UI representation (using the decimals field defined in its mint)
+/// Convert a raw amount to its UI representation (using the decimals field
+/// defined in its mint)
 pub fn amount_to_ui_amount(amount: u64) -> f64 {
     amount as f64 / 10_usize.pow(spl_token::native_mint::DECIMALS as u32) as f64
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -265,8 +265,8 @@ pub fn process_instruction(
                 &[mint_signer_seeds],
             )?;
 
-            // Fully fund the feature id account so the `Tally` instruction will not require any
-            // lamports from the caller
+            // Fully fund the feature id account so the `Tally` instruction will not require
+            // any lamports from the caller
             msg!("Funding feature id account");
             invoke(
                 &system_instruction::transfer(

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,18 +1,20 @@
 //! Program state processor
 
-use crate::{instruction::*, state::*, *};
-use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    clock::Clock,
-    entrypoint::ProgramResult,
-    feature::{self, Feature},
-    msg,
-    program::{invoke, invoke_signed},
-    program_error::ProgramError,
-    pubkey::Pubkey,
-    rent::Rent,
-    system_instruction,
-    sysvar::Sysvar,
+use {
+    crate::{instruction::*, state::*, *},
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        feature::{self, Feature},
+        msg,
+        program::{invoke, invoke_signed},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        rent::Rent,
+        system_instruction,
+        sysvar::Sysvar,
+    },
 };
 
 /// Instruction processor

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -45,7 +45,7 @@ impl Pack for FeatureProposal {
     const LEN: usize = 17; // see `test_get_packed_len()` for justification of "18"
 
     fn pack_into_slice(&self, dst: &mut [u8]) {
-        let data = self.try_to_vec().unwrap();
+        let data = borsh::to_vec(self).unwrap();
         dst[..data.len()].copy_from_slice(&data);
     }
 
@@ -69,20 +69,19 @@ mod tests {
     fn test_get_packed_len() {
         assert_eq!(
             FeatureProposal::get_packed_len(),
-            solana_program::borsh0_10::get_packed_len::<FeatureProposal>()
+            solana_program::borsh1::get_packed_len::<FeatureProposal>()
         );
     }
 
     #[test]
     fn test_serialize_bytes() {
-        assert_eq!(FeatureProposal::Expired.try_to_vec().unwrap(), vec![3]);
+        assert_eq!(borsh::to_vec(&FeatureProposal::Expired).unwrap(), vec![3]);
 
         assert_eq!(
-            FeatureProposal::Pending(AcceptanceCriteria {
+            borsh::to_vec(&FeatureProposal::Pending(AcceptanceCriteria {
                 tokens_required: 0xdeadbeefdeadbeef,
                 deadline: -1,
-            })
-            .try_to_vec()
+            }))
             .unwrap(),
             vec![1, 239, 190, 173, 222, 239, 190, 173, 222, 255, 255, 255, 255, 255, 255, 255, 255],
         );

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -64,7 +64,7 @@ mod tests {
     fn test_get_packed_len() {
         assert_eq!(
             FeatureProposal::get_packed_len(),
-            solana_program::borsh::get_packed_len::<FeatureProposal>()
+            solana_program::borsh0_10::get_packed_len::<FeatureProposal>()
         );
     }
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -12,11 +12,13 @@ use {
 /// Criteria for accepting a feature proposal
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema, PartialEq)]
 pub struct AcceptanceCriteria {
-    /// The balance of the feature proposal's token account must be greater than this amount, and
-    /// tallied before the deadline for the feature to be accepted.
+    /// The balance of the feature proposal's token account must be greater than
+    /// this amount, and tallied before the deadline for the feature to be
+    /// accepted.
     pub tokens_required: u64,
 
-    /// If the required tokens are not tallied by this deadline then the proposal will expire.
+    /// If the required tokens are not tallied by this deadline then the
+    /// proposal will expire.
     pub deadline: UnixTimestamp,
 }
 
@@ -29,7 +31,8 @@ pub enum FeatureProposal {
     Pending(AcceptanceCriteria),
     /// Feature proposal was accepted and the feature is now active
     Accepted {
-        /// The balance of the feature proposal's token account at the time of activation.
+        /// The balance of the feature proposal's token account at the time of
+        /// activation.
         #[allow(dead_code)] // not dead code..
         tokens_upon_acceptance: u64,
     },

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,10 +1,12 @@
 //! Program state
-use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use solana_program::{
-    clock::UnixTimestamp,
-    msg,
-    program_error::ProgramError,
-    program_pack::{Pack, Sealed},
+use {
+    borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    solana_program::{
+        clock::UnixTimestamp,
+        msg,
+        program_error::ProgramError,
+        program_pack::{Pack, Sealed},
+    },
 };
 
 /// Criteria for accepting a feature proposal

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -5,7 +5,6 @@ use {
     solana_program::{
         feature::{self, Feature},
         program_option::COption,
-        pubkey::Pubkey,
         system_program,
     },
     solana_program_test::*,
@@ -133,10 +132,9 @@ async fn test_basic() {
     // Fetch a new blockhash to avoid the second Tally transaction having the same signature as the
     // first Tally transaction
     let recent_blockhash = banks_client
-        .get_new_blockhash(&recent_blockhash)
+        .get_new_latest_blockhash(&recent_blockhash)
         .await
-        .unwrap()
-        .0;
+        .unwrap();
 
     // Tally #2: the acceptance criteria is now met
     let mut transaction =

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -166,7 +166,7 @@ async fn test_basic() {
 async fn test_expired() {
     let feature_proposal = Keypair::new();
 
-    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+    let (banks_client, payer, recent_blockhash) = program_test().start().await;
 
     // Create a new feature proposal
     let mut transaction = Transaction::new_with_payer(

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -1,5 +1,5 @@
 // Mark this test as BPF-only due to current `ProgramTest` limitations when CPIing into the system program
-#![cfg(feature = "test-bpf")]
+#![cfg(feature = "test-sbf")]
 
 use {
     solana_program::{

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -1,4 +1,5 @@
-// Mark this test as BPF-only due to current `ProgramTest` limitations when CPIing into the system program
+// Mark this test as BPF-only due to current `ProgramTest` limitations when
+// CPIing into the system program
 #![cfg(feature = "test-sbf")]
 
 use {
@@ -129,8 +130,8 @@ async fn test_basic() {
     transaction.sign(&[&payer, &feature_proposal], recent_blockhash);
     banks_client.process_transaction(transaction).await.unwrap();
 
-    // Fetch a new blockhash to avoid the second Tally transaction having the same signature as the
-    // first Tally transaction
+    // Fetch a new blockhash to avoid the second Tally transaction having the same
+    // signature as the first Tally transaction
     let recent_blockhash = banks_client
         .get_new_latest_blockhash(&recent_blockhash)
         .await


### PR DESCRIPTION
#### Problem

It's time to move over the SPL program implementations to their specific repos, but it hasn't been done.

#### Summary of changes

Following the PR for the stake interface at https://github.com/solana-program/stake/pull/12, but for SPL. I ran:

```
# add the remote for the source repo
git remote add spl https://github.com/solana-labs/solana-program-library.git
# fetch the master from spl under a different local branch
git fetch spl master:fromspl
git switch fromspl
# be safe, remove the remote
git remote rm spl
# filter the stake related files
python3 ../../git-filter-repo \
  --path feature-proposal/program/src/entrypoint.rs \
  --path feature-proposal/program/src/lib.rs \
  --path feature-proposal/program/src/processor.rs \
  --path feature-proposal/program/src/instruction.rs \
  --path feature-proposal/program/src/state.rs \
  --path feature-proposal/program/tests/functional.rs \
  --path feature-proposal/program/Cargo.toml \
  --path feature-proposal/cli/src/main.rs \
  --path feature-proposal/cli/Cargo.toml \
  --path-rename feature-proposal/program/src/instruction.rs:program/src/instruction.rs \
  --path-rename feature-proposal/program/src/state.rs:program/src/state.rs \
  --path-rename feature-proposal/program/src/entrypoint.rs:program/src/entrypoint.rs \
  --path-rename feature-proposal/program/src/processor.rs:program/src/processor.rs \
  --path-rename feature-proposal/program/src/lib.rs:program/src/lib.rs \
  --path-rename feature-proposal/program/Cargo.toml:program/Cargo.toml \
  --path-rename feature-proposal/program/tests/functional.rs:program/tests/functional.rs \
  --path-rename feature-proposal/cli/src/main.rs:clients/cli/src/main.rs \
  --path-rename feature-proposal/cli/Cargo.toml:clients/cli/Cargo.toml \
  --force
# re-add this repo
git remote add origin git@github.com:joncinque/feature-proposal.git
git fetch origin main
git switch main
git switch fromspl
git rebase main
```